### PR TITLE
fix ~/.local path in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Go on the [TaskWhisperer](https://extensions.gnome.org/extension/1039/taskwhispe
 
 ### Generic (Local installation)
 
-Move files into your locale (~/.locale/share/gnome-shell/extension/taskwhisperer-extension@infinicode.de) directory and enable the extension via the Tweak Tool, it is **important** to move it to **taskwhisperer-extension@infinicode.de** otherwise the extension will not be recognized by gnome.
+Move files into your locale (~/.local/share/gnome-shell/extensions/taskwhisperer-extension@infinicode.de) directory and enable the extension via the Tweak Tool, it is **important** to move it to **taskwhisperer-extension@infinicode.de** otherwise the extension will not be recognized by gnome.
 
 ## Preparation
 


### PR DESCRIPTION
On my system it's `~/.local/share/gnome-shell/extensions/taskwhisperer-extension@infinicode.de` when I'm installing it from extensions.gnome.org. I'm assuming it's a typo but I could be wrong.