### PR TITLE
Use the correct version in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,5 +18,5 @@
   ], 
   "url": "https://github.com/cinatic/taskwhisperer",
   "uuid": "taskwhisperer-extension@infinicode.de",
-  "version": 9
+  "version": 11
 }


### PR DESCRIPTION
The version attribute in `metadata.json` is outdated. This brings it up
to date with the v11 release posted to GitHub.

---

@cinatic I noticed this mismatch in the settings panel. I'm not sure what your preferred versioning process is (i.e. `master` matches current release, `master` matches upcoming release, or something else entirely), but I'm happy to update my PR to match it. (I'm inclined to update it to v12 here since retagging v11 with the updated version would be a different release, but I just updated it to match the tag for the time being.)