### PR TITLE
Fix gnome-shell's breaking change

### DIFF
--- a/taskwhisperer-extension@infinicode.de/dialogs.js
+++ b/taskwhisperer-extension@infinicode.de/dialogs.js
@@ -29,6 +29,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 
+const GObject = imports.gi.GObject;
 const Clutter = imports.gi.Clutter;
 const Lang = imports.lang;
 const Shell = imports.gi.Shell;
@@ -41,16 +42,15 @@ const ngettext = Gettext.ngettext;
 const Main = imports.ui.main;
 const ModalDialog = imports.ui.modalDialog;
 
-
-var ModifyTaskDialog = class extends ModalDialog.ModalDialog{
-
-    constructor(task, dateFormat){
-        super({styleClass: 'taskModificationDialog'});
-        this._init(task, dateFormat)
-    }
+var ModifyTaskDialog = GObject.registerClass({
+        Signals: { 'modify': {
+            param_types: [ GObject.TYPE_STRING ]
+        } },
+    }, class ModifyTaskDialog extends ModalDialog.ModalDialog {
 
     _init(task, dateFormat)
     {
+        super._init({styleClass: 'taskModificationDialog'});
         this._dateFormat = dateFormat;
 
         let mainContentBox = new St.BoxLayout({
@@ -183,18 +183,18 @@ var ModifyTaskDialog = class extends ModalDialog.ModalDialog{
 
         this.emit('modify', params);
     }
-};
+});
 
 
-var CreateTaskDialog = class extends ModalDialog.ModalDialog{
-
-    constructor(dateFormat){
-        super({styleClass: 'createTaskDialog'});
-        this._init(dateFormat)
-    }
+var CreateTaskDialog = GObject.registerClass({
+        Signals: { 'create': {
+            param_types: [ GObject.TYPE_STRING ]
+        } },
+    }, class CreateTaskDialog extends ModalDialog.ModalDialog {
 
     _init(dateFormat)
     {
+        super._init({styleClass: 'createTaskDialog'});
         this._dateFormat = dateFormat;
 
         let mainContentBox = new St.BoxLayout({
@@ -320,4 +320,4 @@ var CreateTaskDialog = class extends ModalDialog.ModalDialog{
 
         this.emit('create', argumentsString);
     }
-};
+});

--- a/taskwhisperer-extension@infinicode.de/extension.js
+++ b/taskwhisperer-extension@infinicode.de/extension.js
@@ -708,7 +708,7 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
 
     _init() {
         this._icon = new St.Icon({
-            icon_name: 'taskwarrior_head',
+            gicon: Gio.icon_new_for_string(Me.dir.get_child('icons').get_path() + "/taskwarrior_head.svg"),
             style_class: 'system-status-icon'
         });
 

--- a/taskwhisperer-extension@infinicode.de/extension.js
+++ b/taskwhisperer-extension@infinicode.de/extension.js
@@ -83,11 +83,7 @@ let _projects = {};
 let _currentPage = 0;
 
 
-const ProjectHeaderBar = class extends PopupMenu.PopupBaseMenuItem {
-    constructor(menu) {
-        super();
-        this._init(menu)
-    }
+const ProjectHeaderBar = GObject.registerClass(class ProjectHeaderBar extends PopupMenu.PopupBaseMenuItem {
 
     _init(menu) {
         this.menu = menu;
@@ -101,11 +97,11 @@ const ProjectHeaderBar = class extends PopupMenu.PopupBaseMenuItem {
             vertical: false
         });
 
-        this.actor = new St.ScrollView({
+        this.scroll = new St.ScrollView({
             style_class: 'projectScrollBox'
         });
 
-        this.actor.add_actor(this.box, {expand: false, x_fill: false, x_align: St.Align.LEFT});
+        this.scroll.add_actor(this.box, {expand: false, x_fill: false, x_align: St.Align.LEFT});
     }
 
     addItem(projectName, projectValue, taskCount, isLast) {
@@ -115,6 +111,7 @@ const ProjectHeaderBar = class extends PopupMenu.PopupBaseMenuItem {
 
         let _projectButton = UiHelper.createButton(projectName + " (" + taskCount + ")", "projectButton", cssClass, Lang.bind(this, this._selectProject));
         _projectButton.ProjectValue = projectValue;
+
 
         this.box.add(_projectButton, {expand: false, x_fill: false, x_align: St.Align.MIDDLE});
     }
@@ -150,13 +147,13 @@ const ProjectHeaderBar = class extends PopupMenu.PopupBaseMenuItem {
     }
 
     hide() {
-        this.actor.hide();
+        this.scroll.hide();
     }
 
     show() {
-        this.actor.show();
+        this.scroll.show();
     }
-};
+});
 
 const ScrollBox = class extends PopupMenu.PopupMenuBase {
     constructor(menu, styleClass) {
@@ -182,6 +179,7 @@ const ScrollBox = class extends PopupMenu.PopupMenuBase {
 
         let scrollBar = this.actor.get_vscroll_bar();
         let appsScrollBoxAdj = scrollBar.get_adjustment();
+        this._gridItems = {};
 
         this.actor.connect('scroll-event', () => {
             if (_hitScrollEvent) {
@@ -201,7 +199,6 @@ const ScrollBox = class extends PopupMenu.PopupMenuBase {
     }
 
     addGridItem(task) {
-        log("whaat 5")
         let dueDateAbbreviation = task.DueDateAbbreviation;
 
         let description = (dueDateAbbreviation ? dueDateAbbreviation + "  " : "") + task.Description;
@@ -347,11 +344,12 @@ const ScrollBox = class extends PopupMenu.PopupMenuBase {
         gridMenu.menu.addMenuItem(_buttonMenu);
         this.addMenuItem(gridMenu);
 
-        this._gridItems[task.ID] = gridMenu;
+        this._gridItems[task.UUID] = gridMenu;
     }
 
     removeTaskFromGrid(taskID) {
-        let gridMenuItem = this._gridItems[task.ID];
+        // never used
+        let gridMenuItem = this._gridItems[taskID];
         if (gridMenuItem) {
             gridMenuItem.destroy();
         }
@@ -394,11 +392,9 @@ const ScrollBox = class extends PopupMenu.PopupMenuBase {
     }
 
     _destroyItems() {
-        let items = this.box.get_children();
-        for (let i = 0; i < items.length; i++) {
-            let boxItem = items[i];
-            boxItem.destroy();
-        }
+        // Using _gridItems instead of .get_children because destroying grid will
+        Object.values(this._gridItems).forEach(c => { c.destroy() });
+        this._gridItems = {};
     }
 
     loadNextItems(cleanItemBox) {
@@ -411,7 +407,6 @@ const ScrollBox = class extends PopupMenu.PopupMenuBase {
             scrollBar.set_adjustment(appsScrollBoxAdj);
 
             _currentPage = 0;
-            this._gridItems = {};
             this._destroyItems();
         }
 
@@ -545,23 +540,18 @@ const ScrollBox = class extends PopupMenu.PopupMenuBase {
     }
 };
 
-var HeaderBar = class extends PopupMenu.PopupBaseMenuItem {
-    constructor(menu) {
-        super();
-        this._init(menu)
-    }
-
+var HeaderBar = GObject.registerClass(class HeaderBar extends PopupMenu.PopupBaseMenuItem {
     _init(menu) {
-        this.menu = menu;
+       this.menu = menu;
 
-        this.actor = new St.BoxLayout({
+        this.box = new St.BoxLayout({
             style_class: this.menu._use_alternative_theme ? "headerBar dark" : "headerBar",
             vertical: false
         });
 
-        this.actor.add(this._createLeftBoxMenu(), {expand: true, x_fill: true, x_align: St.Align.START});
-        this.actor.add(this._createMiddleBoxMenu(), {expand: true, x_fill: true, x_align: St.Align.MIDDLE});
-        this.actor.add(this._createRightBoxMenu(), {expand: false, x_fill: true, x_align: St.Align.END});
+       this.box.add(this._createLeftBoxMenu(), {expand: true, x_fill: true, x_align: St.Align.START});
+       this.box.add(this._createMiddleBoxMenu(), {expand: true, x_fill: true, x_align: St.Align.MIDDLE});
+       this.box.add(this._createRightBoxMenu(), {expand: false, x_fill: true, x_align: St.Align.END});
     }
 
     _createLeftBoxMenu() {
@@ -668,7 +658,7 @@ var HeaderBar = class extends PopupMenu.PopupBaseMenuItem {
         // clear box and fetch new data
         this.menu.taskBox.reloadTaskData(true);
     }
-};
+});
 
 let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButton extends PanelMenu.Button {
 
@@ -778,10 +768,9 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
             Main.panel._menus.addMenu(this.menu);
         }
 
-        this.taskBox = new ScrollBox(this, "");
-
         this._renderPanelMenuHeaderBox();
         this._renderPanelMenuProjectBox();
+        this.taskBox = new ScrollBox(this, "");
 
         this.taskBox.connect('startStop', Lang.bind(this, function (that, task) {
             // log("started: " + task.Started);
@@ -851,7 +840,7 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
             this._panelButtonLabel.hide();
         }
 
-        this.headerBar.actor.style_class = this._use_alternative_theme ? "headerBar dark" : "headerBar";
+        this.headerBar.box.style_class = this._use_alternative_theme ? "headerBar dark" : "headerBar";
     }
 
     checkPositionInPanel() {
@@ -928,7 +917,7 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
         let section = new PopupMenu.PopupMenuSection();
         this.menu.addMenuItem(section);
 
-        section.actor.add_actor(this.headerBar.actor);
+        section.actor.add_actor(this.headerBar.box);
     }
 
     _renderPanelMenuProjectBox() {
@@ -936,13 +925,13 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
         let section = new PopupMenu.PopupMenuSection();
         this.menu.addMenuItem(section);
 
-        section.actor.add_actor(this.projectHeaderBar.actor);
-
-        this.projectHeaderBar.connect("setProject", Lang.bind(this, function (that, task) {
-            this.service.setTaskDone(task.ID, Lang.bind(this, function () {
-                this.taskBox.reloadTaskData(true);
-            }));
-        }));
+        section.actor.add_actor(this.projectHeaderBar.scroll);
+        // never used
+        // this.projectHeaderBar.scroll.connect("setProject", Lang.bind(this, function (that, task) {
+        //     this.service.setTaskDone(task.ID, Lang.bind(this, function () {
+        //         this.taskBox.reloadTaskData(true);
+        //     }));
+        // }));
     }
 
     _openModificationDialog(that, task) {


### PR DESCRIPTION
This PR updates code base to fix the gnome-shell's breaking changes to the class structure, which causes the latest gnome-shell not working (#66).

Fixes are made based on suggestion on [this](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/551#issuecomment-558302621).