### PR TITLE
Change command for launch prefs, tested in 3.36

### DIFF
--- a/taskwhisperer-extension@infinicode.de/extension.js
+++ b/taskwhisperer-extension@infinicode.de/extension.js
@@ -570,7 +570,7 @@ var HeaderBar = GObject.registerClass(class HeaderBar extends PopupMenu.PopupBas
             this.menu.menu.actor.hide();
             this.menu.actor.hide();
             this.menu.actor.show();
-            Util.spawn(["gnome-shell-extension-prefs", "taskwhisperer-extension@infinicode.de"]);
+            Util.spawn(["gnome-extensions", "prefs", `${Me.metadata['uuid']}`]);
         }));
 
         return leftBox;


### PR DESCRIPTION
Gnome shell changed the command to launch preferences?

Using the original command gives me
```sh
$ gnome-shell-extension-prefs taskwhisperer-extension@infinicode.de
(gnome-shell-extension-prefs:52135): GLib-GIO-CRITICAL **: 10:19:08.366: This application can not open files.
```

This PR works in my gnome shell 3.36.