### PR TITLE
prevent unnecessary sync

### DIFF
--- a/taskwhisperer-extension@infinicode.de/extension.js
+++ b/taskwhisperer-extension@infinicode.de/extension.js
@@ -758,13 +758,11 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
             // log("started: " + task.Started);
             if (!task.Started) {
                 this.service.startTask(task.ID, () =>
-                    // log("startTask " + task.ID + "(" + task.Start + ")");
-                    this.taskBox.reloadTaskData(true, true);
+                    this.taskBox.reloadTaskData(true, true)
                 );
             } else {
                 this.service.stopTask(task.ID, () =>
-                    // log("stopTask " + task.ID + "(" + task.Start + ")");
-                    this.taskBox.reloadTaskData(true, true);
+                    this.taskBox.reloadTaskData(true, true)
                 );
             }
         });

--- a/taskwhisperer-extension@infinicode.de/extension.js
+++ b/taskwhisperer-extension@infinicode.de/extension.js
@@ -192,7 +192,7 @@ const ScrollBox = class extends PopupMenu.PopupMenuBase {
             }
         });
 
-        this.reloadTaskData(true, () => {
+        this.reloadTaskData(true, true, () => {
             this.loadNextItems();
         });
     }
@@ -452,12 +452,12 @@ const ScrollBox = class extends PopupMenu.PopupMenuBase {
         });
     }
 
-    reloadTaskData(refreshCache, afterReloadCallback) {
+    reloadTaskData(refreshCache, performSync, afterReloadCallback) {
         let now = new Date().getTime() / 1000;
         if (refreshCache || !_cacheExpirationTime || _cacheExpirationTime < now) {
             _cacheExpirationTime = now + _cacheDurationInSeconds;
 
-            if (this.menu._enable_taskd_sync) {
+            if (this.menu._enable_taskd_sync && performSync) {
                 this.menu.service.syncTasksAsync((data) => {
                     this.menu.service.loadTaskDataAsync(_currentTaskType, _currentProjectName, (data) => {
                         this.processTaskData(afterReloadCallback, data);
@@ -563,7 +563,7 @@ var HeaderBar = GObject.registerClass(class HeaderBar extends PopupMenu.PopupBas
         }));
 
         leftBox.add(UiHelper.createActionButton("refresh", "hatt2", null, () => {
-            this.menu.taskBox.reloadTaskData(true);
+            this.menu.taskBox.reloadTaskData(true, true);
         }));
 
         leftBox.add(UiHelper.createActionButton("settings", "hatt2", "last", () => {
@@ -756,25 +756,25 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
             if (!task.Started) {
                 this.service.startTask(task.ID, Lang.bind(this, function () {
                     // log("startTask " + task.ID + "(" + task.Start + ")");
-                    this.taskBox.reloadTaskData(true);
+                    this.taskBox.reloadTaskData(true, true);
                 }));
             } else {
                 this.service.stopTask(task.ID, Lang.bind(this, function () {
                     // log("stopTask " + task.ID + "(" + task.Start + ")");
-                    this.taskBox.reloadTaskData(true);
+                    this.taskBox.reloadTaskData(true, true);
                 }));
             }
         }));
 
         this.taskBox.connect("setDone", Lang.bind(this, function (that, task) {
             this.service.setTaskDone(task.ID, Lang.bind(this, function () {
-                this.taskBox.reloadTaskData(true);
+                this.taskBox.reloadTaskData(true, true);
             }));
         }));
 
         this.taskBox.connect("setUndone", Lang.bind(this, function (that, task) {
             this.service.setTaskUndone(task.UUID, Lang.bind(this, function () {
-                this.taskBox.reloadTaskData(true);
+                this.taskBox.reloadTaskData(true, true);
             }));
         }));
 
@@ -784,7 +784,7 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
             _isOpen = isOpen;
 
             if (_isOpen) {
-                this.taskBox.reloadTaskData(true);
+                this.taskBox.reloadTaskData(true, true);
             }
         }));
 
@@ -932,7 +932,7 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
                     return;
                 }
 
-                this.taskBox.reloadTaskData(true);
+                this.taskBox.reloadTaskData(true, true);
                 dialog.close();
             });
         });
@@ -958,7 +958,7 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
                         return;
                     }
 
-                    this.taskBox.reloadTaskData(true);
+                    this.taskBox.reloadTaskData(true, true);
                     dialog.close();
                 });
             }));
@@ -993,7 +993,7 @@ let TaskWhispererMenuButton = GObject.registerClass(class TaskWhispererMenuButto
         this._refreshTaskDataTimeoutID = Mainloop.timeout_add_seconds(150, () => {
             // Avoid intervention while user is doing something
             if (!_isOpen) {
-                this.taskBox.reloadTaskData(true);
+                this.taskBox.reloadTaskData(true, true);
             }
 
             this.setRefreshTaskDataTimeout();


### PR DESCRIPTION
Current, if sync is enabled, whenever task-data is asked to be reload a sync will be performed.

However, it is unnecessary for UI changes (i.e. when user clicked on different project tag, sorting button, status:pending/completed). If a sync is performed before reloading TW's data, the UI became laggy. With this PR, actions that might modify data (e.g. create tasks/modify/etc.) will perform a sync, while UI changes would not.