### PR TITLE
Add quotation marks to the executed bash command

### DIFF
--- a/taskwhisperer-extension@infinicode.de/extra/create.sh
+++ b/taskwhisperer-extension@infinicode.de/extra/create.sh
@@ -1,1 +1,6 @@
-bash -c "task add $1"
+params=${1}
+params=${params//$/\\$}
+params=${params//\"/\\\"}
+params=${params//\)/\\\)}
+params=${params//\(/\\\(}
+bash -c "task add ${params}"

--- a/taskwhisperer-extension@infinicode.de/taskService.js
+++ b/taskwhisperer-extension@infinicode.de/taskService.js
@@ -401,7 +401,7 @@ var TaskService = class TaskService {
         // FIXME: Gio.Subprocess: due to only passing string vector is allowed, it's not possible to directly pass the
         //        input of the user to subprocess (why & how, if you can answer then please send msg to fh@infinicode.de)
         //        bypassing problem with own shell script
-        let shellProc = Gio.Subprocess.new(['/bin/sh', EXTENSIONDIR + '/extra/create.sh', params], Gio.SubprocessFlags.STDOUT_PIPE + Gio.SubprocessFlags.STDERR_MERGE);
+        let shellProc = Gio.Subprocess.new(['/usr/bin/env', 'bash', EXTENSIONDIR + '/extra/create.sh', params], Gio.SubprocessFlags.STDOUT_PIPE + Gio.SubprocessFlags.STDERR_MERGE);
 
         shellProc.wait_async(null, function (obj, result) {
             let shellProcExited = true;


### PR DESCRIPTION
Currently we can't add tasks that contain bash symbols that should be quouted: `'`, `"`, `(`, `)`:
![image](https://user-images.githubusercontent.com/12023585/96359424-7f274000-111b-11eb-969c-07b3d6cf29c1.png)

Moreover, we can execute the arbitrary command in this way:
![image](https://user-images.githubusercontent.com/12023585/96359377-fb6d5380-111a-11eb-89c5-a6c0ddfa143d.png)

The task will not be added, but the command will be executed.

This PR will fix these issues.